### PR TITLE
[Training]: Configure pseudo-labels or text labels as targets in KD

### DIFF
--- a/training/run_distillation.py
+++ b/training/run_distillation.py
@@ -593,7 +593,7 @@ def load_multiple_datasets(
         # resample to specified sampling rate
         dataset = dataset.cast_column("audio", datasets.features.Audio(sampling_rate))
         dataset_features = dataset.features.keys()
-        columns_to_keep = {"audio", "sentence"}
+        columns_to_keep = {"audio", "text"}
 
         if dataset_dict["text_column_name"] not in dataset_features:
             raise ValueError(
@@ -603,8 +603,8 @@ def load_multiple_datasets(
             )
 
         # blanket renaming of all transcription columns to text
-        if dataset_dict["text_column_name"] != "sentence":
-            dataset = dataset.rename_column(dataset_dict["text_column_name"], "sentence")
+        if dataset_dict["text_column_name"] != "text":
+            dataset = dataset.rename_column(dataset_dict["text_column_name"], "text")
 
         if use_pseudo_labels:
             if "whisper_transcript" not in dataset_features:
@@ -1025,7 +1025,7 @@ def main():
     )
     wer_threshold = data_args.wer_threshold
     use_pseudo_labels = data_args.use_pseudo_labels
-    train_text_column_name = "whisper_transcript" if use_pseudo_labels else "sentence"
+    train_text_column_name = "whisper_transcript" if use_pseudo_labels else "text"
 
     # 10.2: filter based on maximum number of training/evaluation samples
     if training_args.do_train and data_args.max_train_samples is not None:
@@ -1066,7 +1066,7 @@ def main():
     filter_by_wer_threshold = partial(
         raw_datasets["train"].filter,
         function=is_wer_in_range,
-        input_columns=["sentence", "whisper_transcript"],
+        input_columns=["text", "whisper_transcript"],
     )
 
     if wer_threshold is not None and use_pseudo_labels:


### PR DESCRIPTION
Updates the distillation script, such that the user can configure between training on pseudo-labels or text labels as their targets. This enables the user to run "knowledge distillation", but directly on the text labels provided by an ASR dataset, such as Common Voice. The pseudo-labelling step can effectively be skipped when training like this.

To train directly on the text labels provided in the dataset, set `--use_pseudo_labels=False` and pass the correct `--text_column_name` for your text targets. For example, training `distil-large-v3` on the Common Voice 15 dataset **with no pseudo-labels**:
```bash
#!/usr/bin/env bash

accelerate launch --mixed_precision=bf16 run_distillation.py \
  --model_name_or_path "./distil-large-v3-init" \
  --teacher_model_name_or_path "openai/whisper-large-v3" \
  --train_dataset_name "mozilla-foundation/common_voice_15_0" \
  --train_dataset_config_name "de" \
  --train_split_name "train" \
  --text_column_name "sentence" \
  --eval_dataset_name "mozilla-foundation/common_voice_15_0" \
  --eval_dataset_config_name "de" \
  --eval_split_name "validation" \
  --eval_text_column_name "sentence" \
  --eval_steps 5000 \
  --save_steps 5000 \
  --warmup_steps 500 \
  --learning_rate 1e-4 \
  --lr_scheduler_type "linear" \
  --logging_steps 25 \
  --save_total_limit 1 \
  --max_steps 50000 \
  --per_device_train_batch_size 64 \
  --per_device_eval_batch_size 64 \
  --dataloader_num_workers 16 \
  --preprocessing_num_workers 16 \
  --ddp_timeout 7200 \
  --dtype "bfloat16" \
  --output_dir "./" \
  --use_pseudo_labels "false" \
  --condition_on_prev_probability "0.0" \
  --do_train \
  --do_eval \
  --gradient_checkpointing \
  --overwrite_output_dir \
  --predict_with_generate \
  --freeze_encoder \
  --streaming
```

=> we use the same target labels as fine-tuning, but with the teacher influence during training with the KL-div loss.