### PR TITLE
mask BOS in prompted ids

### DIFF
--- a/training/run_distillation.py
+++ b/training/run_distillation.py
@@ -416,7 +416,7 @@ class DataCollatorSpeechSeq2SeqWithPadding:
         labels = labels.masked_fill(labels_mask.ne(1), -100)
 
         # replace initial prompt tokens with -100 to ignore correctly when computing the loss
-        bos_index = torch.argmax((labels == self.decoder_start_token_id).long(), dim=1)
+        bos_index = torch.argmax((labels == self.decoder_start_token_id).long(), dim=1) + 1
         prompt_mask = torch.arange(labels.shape[1]) < bos_index[:, None]
         labels = torch.where(prompt_mask, -100, labels)
 


### PR DESCRIPTION
When conditioning on previous context text, we should mask the previous tokens **and** the BOS token. Training the model to predict the decoder input id doesn't make sense - this would be asking the model to "predict" when the prompt ids finish and the transcription starts. At inference time, the BOS token is provided as a decoder input id, so it should not be predicted by the model, only passed as an input. 