### PR TITLE
correctly mask bos in prompted ids

### DIFF
--- a/training/run_distillation.py
+++ b/training/run_distillation.py
@@ -416,7 +416,8 @@ class DataCollatorSpeechSeq2SeqWithPadding:
         labels = labels.masked_fill(labels_mask.ne(1), -100)
 
         # replace initial prompt tokens with -100 to ignore correctly when computing the loss
-        bos_index = torch.argmax((labels == self.decoder_start_token_id).long(), dim=1) + 1
+        bos_index = torch.argmax((labels == self.decoder_start_token_id).long(), dim=1)
+        bos_index = torch.where(bos_index > 0, bos_index + 1, bos_index)
         prompt_mask = torch.arange(labels.shape[1]) < bos_index[:, None]
         labels = torch.where(prompt_mask, -100, labels)
 


### PR DESCRIPTION
This PR ensures the padding mask is correctly constructed for both the un-prompted and prompted cases.

## Un-prompted

Given input ids of:
```
<bos>       a        b        c        d        e     <eos>
```

The corresponding labels are the right-shifted ids and the decoder input ids the first N-1 ids:
```
labels:          a        b        c        d        e     <eos>

                 ↑        ↑        ↑        ↑        ↑        ↑

input ids:    <bos>       a        b        c        d        e        
```

## Prompted

For prompted ids of format:
```
<prev>    f        g        h        i     <bos>    a        b        c        d        e     <eos>
```
We should have:

```
labels:                                                   a        b        c        d        e     <eos>

                                                          ↑        ↑        ↑        ↑        ↑        ↑

input ids:    <prev>    f        g        h        i     <bos>     a        b        c        d        e          
```

=> the important aspect is that in the labels, we do **not** predict the `<bos>` token id, as was done prior to #77. The bug in #77 was that for un-prompted ids, we were also masking the first target label (`a`). This PR corrects this behaviour. 