### PR TITLE
Fix model saving at the end of training

### DIFF
--- a/training/run_distillation.py
+++ b/training/run_distillation.py
@@ -1573,13 +1573,6 @@ def main():
                     if accelerator.is_main_process:
                         rotate_checkpoints(training_args.save_total_limit, output_dir=training_args.output_dir)
 
-                        if cur_step == total_train_steps:
-                            # un-wrap student model for save
-                            student_model = accelerator.unwrap_model(student_model)
-                            student_model.save_pretrained(training_args.output_dir)
-                            # re-wrap student model for final eval
-                            student_model = accelerator.prepare(student_model)
-
                         if training_args.push_to_hub:
                             upload_folder(
                                 folder_path=training_args.output_dir,
@@ -1674,6 +1667,11 @@ def main():
 
                 # break condition
                 if cur_step == total_train_steps:
+
+                    # un-wrap student model for save
+                    student_model = accelerator.unwrap_model(student_model)
+                    student_model.save_pretrained(training_args.output_dir)
+                
                     continue_training = False
                     break
 

--- a/training/run_distillation.py
+++ b/training/run_distillation.py
@@ -1671,7 +1671,15 @@ def main():
                     # un-wrap student model for save
                     student_model = accelerator.unwrap_model(student_model)
                     student_model.save_pretrained(training_args.output_dir)
-                
+
+                    if training_args.push_to_hub:
+                        upload_folder(
+                            folder_path=training_args.output_dir,
+                            repo_id=repo_name,
+                            repo_type="model",
+                            commit_message=f"Saving final weights of step {cur_step}",
+                        )
+
                     continue_training = False
                     break
 


### PR DESCRIPTION
Fix saving of the model at the end of training: save it after the last evaluation so that there is no need to prepare the model with Accelerate, which was previously causing errors.