### PR TITLE
[eval] benchmark generation speed

### DIFF
--- a/training/run_eval.py
+++ b/training/run_eval.py
@@ -676,7 +676,7 @@ def main():
     forced_decoder_ids = processor.get_decoder_prompt_ids(
         task=data_args.task, 
         language=data_args.language, 
-        no_timestamps=data_args.return_timestamps
+        no_timestamps=not data_args.return_timestamps
     )
 
     def benchmark(batch):

--- a/training/run_eval.py
+++ b/training/run_eval.py
@@ -294,7 +294,13 @@ class DataTrainingArguments:
     only_short_form: bool = field(
         default=False,
         metadata={
-            "help": "Whether the evaluation should be short form (filter out samples >= 30sec)." 
+            "help": "Whether the evaluation should be only short form (filter out samples > 30sec)." 
+        }
+    )
+    only_long_form: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether the evaluation should be only long form (filter out samples <= 30sec)." 
         }
     )
 
@@ -493,6 +499,9 @@ def main():
         
         if data_args.only_short_form:
             sub_dataset = sub_dataset.filter(lambda x: len(x["audio"]["array"]) / x["audio"]["sampling_rate"] <= 30)
+
+        if data_args.only_long_form:
+            sub_dataset = sub_dataset.filter(lambda x: len(x["audio"]["array"]) / x["audio"]["sampling_rate"] > 30)
 
         if dataset_dict["text_column_name"] not in list(sub_dataset.features.keys()):
             raise ValueError(

--- a/training/run_eval.py
+++ b/training/run_eval.py
@@ -782,9 +782,6 @@ def main():
                     **gen_kwargs
                 )
                 gen_time = time.time() - start_time
-
-                n_generated_tokens = n_tokens * data_args.batch_size
-                tokens_per_secs.append(n_generated_tokens / gen_time)
             
             else:
                 # benchmark time to generate fixed number of tokens
@@ -797,8 +794,8 @@ def main():
                 )
                 gen_time = time.time() - start_time
 
-                n_generated_tokens = n_tokens * data_args.batch_size
-                tokens_per_secs.append(n_generated_tokens / gen_time)
+            n_generated_tokens = n_tokens * data_args.batch_size
+            tokens_per_secs.append(n_generated_tokens / gen_time)
 
         return tokens_per_secs
 

--- a/training/run_eval.py
+++ b/training/run_eval.py
@@ -787,8 +787,6 @@ def main():
                 tokens_per_secs.append(n_generated_tokens / gen_time)
             
             else:
-                n_generated_tokens = []
-
                 # benchmark time to generate fixed number of tokens
                 start_time = time.time()
                 _ = model_pipeline.model.generate(

--- a/training/run_eval.py
+++ b/training/run_eval.py
@@ -753,7 +753,7 @@ def main():
                 )            
             )
 
-            # benchmark time to generate exactly 20 tokens
+            # benchmark time to generate fixed number of tokens
             n_tokens = data_args.num_tokens
             start_time = time.time()
             _ = model.generate(

--- a/training/run_eval.py
+++ b/training/run_eval.py
@@ -889,7 +889,7 @@ def main():
 
         if data_args.precise_tok_per_s:
             # evaluate generation speed for few batch
-            tokens_per_secs = benchmark_gen_time(data_args.num_batches)
+            tokens_per_secs = benchmark_gen(data_args.num_batches)
 
         datasets_evaluated_progress_bar.write(f"Start benchmarking {split}...")
         result_iter = iter(result_datasets[split])

--- a/training/run_eval.py
+++ b/training/run_eval.py
@@ -23,8 +23,6 @@ import os
 import sys
 import tempfile
 import time
-import types
-import copy
 from dataclasses import dataclass, field
 from typing import Optional
 

--- a/training/run_eval.py
+++ b/training/run_eval.py
@@ -463,8 +463,6 @@ def main():
             num_proc=data_args.preprocessing_num_workers,
         )
 
-        sub_dataset = sub_dataset.filter(lambda x: len(x["audio"]["array"]) / x["audio"]["sampling_rate"] <= 30)
-
         if dataset_dict["text_column_name"] not in list(sub_dataset.features.keys()):
             raise ValueError(
                 f"`--text_column_name` {dataset_dict['text_column_name']} not found in the evaluation "

--- a/training/run_eval.py
+++ b/training/run_eval.py
@@ -291,6 +291,12 @@ class DataTrainingArguments:
             "help": "Number of batches for the tok/sec calculation with precise_tok_per_s"
         }
     )
+    only_short_form: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether the evaluation should be short form (filter out samples >= 30sec)." 
+        }
+    )
 
 
 
@@ -484,6 +490,9 @@ def main():
             streaming=data_args.streaming,
             num_proc=data_args.preprocessing_num_workers,
         )
+        
+        if data_args.only_short_form:
+            sub_dataset = sub_dataset.filter(lambda x: len(x["audio"]["array"]) / x["audio"]["sampling_rate"] <= 30)
 
         if dataset_dict["text_column_name"] not in list(sub_dataset.features.keys()):
             raise ValueError(


### PR DESCRIPTION
Add benchmarking of token generation speed. To do so, we generate a fixed number of tokens (using `min_new_tokens=max_new_tokens=20`), then compute number of generated tokens per sec for the given batch size with dummy batch, repeat 100 times and average.