### PR TITLE
Freeze decoder

### DIFF
--- a/training/run_distillation.py
+++ b/training/run_distillation.py
@@ -37,6 +37,7 @@ import torch.nn as nn
 import transformers
 from accelerate import Accelerator
 from accelerate.logging import get_logger
+from accelerate.utils import set_seed
 from datasets import (
     DatasetDict,
     IterableDataset,
@@ -57,8 +58,7 @@ from transformers import (
     WhisperForConditionalGeneration,
     WhisperProcessor,
     WhisperTokenizerFast,
-    get_scheduler,
-    set_seed,
+    get_scheduler
 )
 from transformers.modeling_outputs import BaseModelOutput
 from transformers.models.whisper.english_normalizer import BasicTextNormalizer, EnglishTextNormalizer

--- a/training/run_distillation.py
+++ b/training/run_distillation.py
@@ -337,6 +337,14 @@ class DataTrainingArguments:
         default="distil-whisper",
         metadata={"help": "The name of the wandb project."},
     )
+    wandb_name: str = field(
+        default=None,
+        metadata={"help": "The name of the wandb run."},
+    )
+    wandb_dir: str = field(
+        default="./wandb",
+        metadata={"help": "The dir where wandb metadata will be stored."},
+    )
 
 
 @dataclass
@@ -772,7 +780,14 @@ def main():
         project_dir=training_args.output_dir,
     )
 
-    accelerator.init_trackers(project_name=data_args.wandb_project)
+    accelerator.init_trackers(
+        project_name=data_args.wandb_project,
+        init_kwargs={
+            "wandb": {"name": data_args.wandb_name,
+                      "dir": data_args.wandb_dir}
+        }
+
+    )
 
     # 3. Set-up basic logging
     # Create one log on every process with the configuration for debugging


### PR DESCRIPTION
Add the possibility to freeze the decoder. Note freezing the decoder will freeze the encoder `embed_tokens` layer that is by default tied to `proj_out` layers (not a layer of the decoder). This way, `proj_out` also gets frozen, it is thus necessary to unfreeze it. 

other minor changes:
- use `set_seed` [from Accelerate](https://huggingface.co/docs/accelerate/v0.1.0/internal.html#accelerate.utils.set_seed) that will also set the seed for numpy
- add naming of wandb runs