### PR TITLE
[pseudo-labelling] fix concatenate datasets

### DIFF
--- a/training/run_pseudo_labelling.py
+++ b/training/run_pseudo_labelling.py
@@ -649,7 +649,7 @@ def main():
 
             audio.append(audio_array)
             text.append(sample_text)
-            sample_speaker_id.append(sample_id)
+            sample_speaker_id.append(sample_speaker_id)
 
         # initialize concatenations
         concat_audio = [audio[0]]

--- a/training/run_pseudo_labelling.py
+++ b/training/run_pseudo_labelling.py
@@ -970,16 +970,17 @@ def main():
                         concatenated_prev.append(prompt_ids)
                 return {"condition_on_prev": concatenated_prev}
 
-            with accelerator.main_process_first():
-                raw_datasets[split] = raw_datasets[split].map(
-                    add_concatenated_text,
-                    input_columns=["eval_preds", "condition_on_prev"],
-                    remove_columns=["eval_preds"],
-                    desc="Setting condition on prev...",
-                    batched=True,
-                    batch_size=preprocessing_batch_size,
-                    num_proc=num_workers,
-                )
+            if data_args.concatenate_audio:
+                with accelerator.main_process_first():
+                    raw_datasets[split] = raw_datasets[split].map(
+                        add_concatenated_text,
+                        input_columns=["eval_preds", "condition_on_prev"],
+                        remove_columns=["eval_preds"],
+                        desc="Setting condition on prev...",
+                        batched=True,
+                        batch_size=preprocessing_batch_size,
+                        num_proc=num_workers,
+                    )
 
     logger.info("***** Running Labelling *****")
     logger.info("  Instantaneous batch size per device =" f" {training_args.per_device_eval_batch_size}")


### PR DESCRIPTION
This PR includes changes to fix behavior concerning the `--concatenate_audio` flag. In particular, function `concatenate_dataset` now handle edge cases that before led to skipping last sample, associating wrong speaker and wrong `condition_on_prev` for first sample.