### PR TITLE
save the config/processor/generation config during intermediate saves

### DIFF
--- a/training/run_distillation.py
+++ b/training/run_distillation.py
@@ -1613,6 +1613,11 @@ def main():
                 if (cur_step % training_args.save_steps == 0) or cur_step == total_train_steps:
                     intermediate_dir = os.path.join(training_args.output_dir, f"checkpoint-{cur_step}-epoch-{epoch}")
                     accelerator.save_state(output_dir=intermediate_dir)
+                    feature_extractor.save_pretrained(intermediate_dir)
+                    tokenizer.save_pretrained(intermediate_dir)
+                    config.save_pretrained(intermediate_dir)
+                    student_model.generation_config.save_pretrained(intermediate_dir)
+
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
                         rotate_checkpoints(training_args.save_total_limit, output_dir=training_args.output_dir)


### PR DESCRIPTION
As discussed [here](https://huggingface.co/distil-whisper/distil-medium.en/discussions/14#66757ac62c8c886d4dd88c05), this PR simply saves config/processor/generation config to make checkpoints evaluable using [run_eval.py](https://github.com/huggingface/distil-whisper/blob/main/training/run_eval.py). 