### PR TITLE
Fix previous text prepending

### DIFF
--- a/training/run_distillation.py
+++ b/training/run_distillation.py
@@ -1189,13 +1189,13 @@ def main():
                 # check that the length of the prompt does not exceed more than half the max label length (224)
                 if len(prev_ids) > prompt_cutoff_length:
                     prev_ids = prev_ids[-prompt_cutoff_length + 1 :]
-                    prev_ids = [decoder_prev_token_id] + prev_ids
 
                 # and that the total length of the labels does not exceed the max label length (448)
-                if len(prev_ids + token_ids) > max_label_length:
-                    trim_length = len(prev_ids + token_ids) - max_label_length + 1
+                if len(prev_ids + token_ids) + 1 > max_label_length:
+                    trim_length = len(token_ids) - max_label_length + 1
                     prev_ids = prev_ids[trim_length:]
-                    prev_ids = [decoder_prev_token_id] + prev_ids
+
+                prev_ids = [decoder_prev_token_id] + prev_ids
 
                 token_ids = prev_ids + token_ids
 


### PR DESCRIPTION
Hi 👋,

Thank you for continuously adding more features to the Whisper distillation code!

As I reviewed the section on prepending previous text during the preparation of training data, I made the following adjustments based on my interpretation:

1. Moved the prepending of `decoder_prev_token_id` to the end to ensure it's always triggered, even when `prev_ids` aren't cut by the previous two conditions
2. Updated the total length check to `len(prev_ids + token_ids) + 1`, which now includes `decoder_prev_token_id` since it's always added
3. Removed `prev_ids` from the `trim_length` calculation. For instance, with 3 `prev_ids` and 3 `token_ids` and a `max_label_length` of 6, we should retain only the last 2 tokens in `prev_ids`, calculated as `max_label_length - len(token_ids) - 1` = 6 - 3 - 1 = 2