### PR TITLE
Best saved checkpoint is deleted just after saving when WER goes below 10%

### DIFF
--- a/training/run_distillation.py
+++ b/training/run_distillation.py
@@ -719,7 +719,7 @@ def sorted_best_checkpoints(output_dir=None, checkpoint_prefix="checkpoint"):
     for path in glob_checkpoints:
         regex_match = re.search(r"val-wer-([0-9]+\.[0-9]+)", path)
         if regex_match is not None and regex_match.groups() is not None:
-            ordering_and_checkpoint_path.append((regex_match.groups(1), path))
+            ordering_and_checkpoint_path.append((float(regex_match.groups(1)[0]), path))
 
     checkpoints_sorted = sorted(ordering_and_checkpoint_path, reverse=True)
     checkpoints_sorted = [checkpoint[1] for checkpoint in checkpoints_sorted]


### PR DESCRIPTION
I observed that the `sorted_best_checkpoints` method:
 https://github.com/huggingface/distil-whisper/blob/9422916d714bde70ea9d88e13c56f877ced1e76b/training/run_distillation.py#L714
 
 So when the WER of best model goes down from 10 to 9, from then it removes the newest best checkpoint. 
 That's because `sorted` method does not sort string values correctly:
 https://github.com/huggingface/distil-whisper/blob/9422916d714bde70ea9d88e13c56f877ced1e76b/training/run_distillation.py#L721-L724

For example, if there are the following best saved models:
```
['distil-whisper-large-v3-ft-checkpoints/checkpoint-145000-epoch-18-val-wer-10.385',
 'distil-whisper-large-v3-ft-checkpoints/checkpoint-150000-epoch-19-val-wer-10.238',
 'distil-whisper-large-v3-ft-checkpoints/checkpoint-180000-epoch-23-val-wer-9.965']
 ```
 after sorting, the sorted directory-names of saved models are in a wrong order:
 ```
 [(('9.965',), 'distil-whisper-large-v3-ft-checkpoints/checkpoint-180000-epoch-23-val-wer-9.965'),
 (('10.385',), 'distil-whisper-large-v3-ft-checkpoints/checkpoint-145000-epoch-18-val-wer-10.385'),
 (('10.238',), 'distil-whisper-large-v3-ft-checkpoints/checkpoint-150000-epoch-19-val-wer-10.238')]
 ```
 
 Solution is to convert the matched regex of wer value to float number:
https://github.com/hannan72/distil-whisper/blob/289c482ea4947fa48d645b7f0ad4080c92529ef9/training/run_distillation.py#L722